### PR TITLE
Fix compatibility with `pymc3` and `pymc==4.0.0b2`

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -8,6 +8,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
+        pymc-version: ["without", "pymc==4.0.0b2", "pymc3"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -17,30 +18,28 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -e .
-        pip install flake8 pytest pytest-cov codecov wheel
+        pip install -r requirements-dev.txt
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings
         flake8 . --count --exit-zero --statistics
-    - name: Test with pytest
+    - name: Test without PyMC
       run: |
         pytest --cov=./murefi --cov-append --cov-report xml --cov-report term-missing murefi/tests.py
-    - name: Install PyMC3
+    - name: Install and test with PyMC
+      if: matrix.pymc-version != 'without'
       run: |
-        pip install pymc3 
-    - name: Test with PyMC3
-      run: |
+        pip install ${{ matrix.pymc-version }}
         pytest --cov=./murefi --cov-append --cov-report xml --cov-report term-missing murefi/tests.py
-    - name: Install sunode
+    - name: Install and test with sunode
+      if: matrix.pymc-version != 'without'
       run : |
         conda install -c conda-forge sunode
-    - name: Test with sunode
-      run : |
         pytest --cov=./murefi --cov-append --cov-report xml --cov-report term-missing murefi/tests.py
     - name: Upload coverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       if: matrix.python-version == 3.8
       with:
         file: ./coverage.xml

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -26,6 +26,7 @@ jobs:
         # exit-zero treats all errors as warnings
         flake8 . --count --exit-zero --statistics
     - name: Test without PyMC
+      if: matrix.pymc-version == 'without'
       run: |
         pytest --cov=./murefi --cov-append --cov-report xml --cov-report term-missing murefi/tests.py
     - name: Install and test with PyMC

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,22 +19,10 @@ jobs:
         python-version: 3.7
     - name: Install dependencies
       run: |
-        pip install -e . 
-        pip install flake8 pytest pytest-cov twine wheel
-    - name: Test with pytest
+        pip install -e .
+        pip install -r requirements-dev.txt
+    - name: Test without PyMC
       run: |
-        pytest --cov=./murefi --cov-append --cov-report xml --cov-report term-missing murefi/tests.py
-    - name: Install PyMC3 and PyGMO
-      run: |
-        pip install pymc3
-    - name: Test with PyMC3 
-      run: |
-        pytest --cov=./murefi --cov-append --cov-report xml --cov-report term-missing murefi/tests.py
-    - name: Install sunode
-      run : |
-        conda install -c conda-forge sunode
-    - name: Test with sunode
-      run : |
         pytest --cov=./murefi --cov-append --cov-report xml --cov-report term-missing murefi/tests.py
     - name: Build package
       run: |

--- a/murefi/__init__.py
+++ b/murefi/__init__.py
@@ -4,4 +4,4 @@ from . import objectives
 from . ode import BaseODEModel
 
 
-__version__ = '5.0.1'
+__version__ = "5.1.0"

--- a/murefi/objectives.py
+++ b/murefi/objectives.py
@@ -49,7 +49,7 @@ def for_dataset(dataset: Dataset, model: BaseODEModel, parameter_mapping: Parame
                 L.append(ll)
 
         if is_symbolic:
-            return symbolic.theano.tensor.sum(L)
+            return symbolic.at.sum(L)
         else:
             L = numpy.sum(L)
             if numpy.isnan(L):

--- a/murefi/ode.py
+++ b/murefi/ode.py
@@ -188,7 +188,7 @@ class BaseODEModel(object):
         if symbolic_mode:
             masks = template.get_observation_indices(list(template.keys()))
             # symbolically predict for all timepoints
-            if symbolic.HAVE_SUNODE:
+            if symbolic.HAS_SUNODE:
                 y_hat_all = symbolic.solve_sunode(
                     self.dydt,
                     self.independent_keys,

--- a/murefi/symbolic.py
+++ b/murefi/symbolic.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, Dict, Sequence, Tuple, Union
 from typing_extensions import TypeAlias
 import numpy
 import base64
@@ -130,7 +130,10 @@ class IntegrationOp(Op):
         return output_shapes
 
 
-def named_with_shapes_dict(vars, names):
+def named_with_shapes_dict(
+    vars: Dict[str, Union[numpy.ndarray, Variable]],
+    names: Sequence[str]
+) -> Dict[str, Tuple[Union[numpy.ndarray, Variable], Tuple[int, ...]]]:
     d = {}
     for n, name in enumerate(names):
         v = vars[n]
@@ -138,6 +141,7 @@ def named_with_shapes_dict(vars, names):
             d[name] = (v, ())
         else:
             v = numpy.array(v).astype(_backend.config.floatX)
+            d[name] = (v, numpy.shape(v))
     return d
 
 
@@ -165,7 +169,7 @@ def solve_sunode(
     y0 = named_with_shapes_dict(y0, independent_keys)
     params = named_with_shapes_dict(ode_parameters, parameter_names)
     params['extra'] = numpy.zeros(1)
-    solution, flat_solution, problem, sol, y0_flat, params_subs_flat, flat_sens, wrapper = sunode.wrappers.as_theano.solve_ivp(
+    solution, *_ = sunode.wrappers.as_theano.solve_ivp(
         y0=y0,
         params=params,
         rhs=dydt_dict,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+codecov
+flake8
+pytest
+pytest-cov
+wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-pandas
-numpy
-scipy
+calibr8>=6.2.1
 h5py
-calibr8>=6.0.0
+numpy
+pandas
+scipy
+typing_extensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,7 @@ calibr8>=6.2.1
 h5py
 numpy
 pandas
-scipy
+
+# Pin SciPy until pymc>=4.0.0b is released
+scipy<1.8.0
 typing_extensions

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,12 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import pathlib
 import setuptools
 
 __packagename__ = 'murefi'
+ROOT = pathlib.Path(__file__).parent
+
 
 def get_version():
     import pathlib, re
@@ -50,11 +53,5 @@ setuptools.setup(name = __packagename__,
             'Topic :: Scientific/Engineering',
             'Topic :: Scientific/Engineering :: Mathematics',
         ],
-        install_requires=[
-            'pandas',
-            'numpy',
-            'scipy',
-            'h5py',
-            'calibr8>=6.0.0'
-        ]
+        install_requires=[open(pathlib.Path(ROOT, "requirements.txt")).readlines()],
 )


### PR DESCRIPTION
* The test pipeline was refactored to test all currently supported combinations.
* For simplicity the PyMC/sunode integration tests were removed from the release pipeline.
* Dependencies were moved into `requirements.txt` and `requirements-dev.txt` like we have in other projects.
* Some type hints were added alongside a fix of an incorrectly typed dict element assignment.

Closes #3