### PR TITLE
Reduce unnecessary job redundancy

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,6 +1,6 @@
 name: pipeline
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   test-job:


### PR DESCRIPTION
Quoting the docs:
"If multiple triggering events for your workflow occur at the same time,
multiple workflow runs will be triggered."

In this PR 9 jobs were triggered.
![grafik](https://user-images.githubusercontent.com/5894642/155178190-59771ff3-1cd0-4658-b0e3-3166e7d5e120.png)


Compare this to #4 where each job was triggered twice!

![grafik](https://user-images.githubusercontent.com/5894642/155178122-9bf5889b-3470-4b1a-97e9-c2cae7c58033.png)
